### PR TITLE
Фикс наследования классов

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -316,9 +316,12 @@ export default defineComponent({
       const ariaActiveDescendant = getObjectValueByPath(this.$refs.menu, 'activeTile.id')
       const autocomplete = getObjectValueByPath(input.props, 'autocomplete', 'off')
 
-      input.props = mergeProps(input.props, {
+      // в оригинале class не пробрасывался в инпут
+      input.props = mergeProps({
+        ...input.props,
+        class: undefined
+      }, {
         'aria-activedescendant': ariaActiveDescendant,
-        class: undefined,
         autocomplete,
         value: this.internalSearch,
       })

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -6,7 +6,7 @@ import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelec
 import VTextField from '../VTextField/VTextField'
 
 // Utilities
-import mergeData from '../../util/mergeData'
+import { defineComponent, mergeProps } from 'vue'
 import {
   getObjectValueByPath,
   getPropertyFromItem,
@@ -14,7 +14,7 @@ import {
 } from '../../util/helpers'
 
 // Types
-import { PropType, VNode, defineComponent } from 'vue'
+import { PropType, VNode } from 'vue'
 import { PropValidator } from 'vue/types/options'
 
 const defaultMenuProps = {
@@ -313,9 +313,13 @@ export default defineComponent({
     genInput () {
       const input = VTextField.methods.genInput.call(this)
 
-      input.data = mergeData(input.props!, {
-        'aria-activedescendant': getObjectValueByPath(this.$refs.menu, 'activeTile.id'),
-        autocomplete: getObjectValueByPath(input.data!, 'attrs.autocomplete', 'off'),
+      const ariaActiveDescendant = getObjectValueByPath(this.$refs.menu, 'activeTile.id')
+      const autocomplete = getObjectValueByPath(input.props, 'autocomplete', 'off')
+
+      input.props = mergeProps(input.props, {
+        'aria-activedescendant': ariaActiveDescendant,
+        class: undefined,
+        autocomplete,
         value: this.internalSearch,
       })
 

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.ts
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.ts
@@ -6,10 +6,12 @@ import './VRadioGroup.sass'
 import VInput from '../VInput'
 import { BaseItemGroup } from '../VItemGroup/VItemGroup'
 
-// Types
+// Utilities
+import { mergeProps, h } from 'vue'
 import mixins from '../../util/mixins'
-import { PropType } from 'vue'
-import {h} from 'vue'
+
+// Types
+import type { PropType } from 'vue'
 
 const baseMixins = mixins(
   VInput,
@@ -88,10 +90,7 @@ export default baseMixins.extend({
   render () {
     const vnode = VInput.render.call(this)
 
-    vnode.props = {
-      ...vnode.props,
-      ...this.attrs$
-    }
+    vnode.props = mergeProps(vnode.props, this.attrs$);
 
     return vnode
   },


### PR DESCRIPTION
вью2
<img width="1169" height="218" alt="image" src="https://github.com/user-attachments/assets/c3b40b5c-6834-477a-a660-bb2cd93c0a7b" />

сломанный вариант на вью3
<img width="1178" height="257" alt="image" src="https://github.com/user-attachments/assets/d0ddab1a-37e7-4a04-ba33-7b5c17c7ebe5" />


для автокомплита
пропсы кроме класса прокидывались

```
        <v-col cols="12">
          <v-autocomplete
            v-model="value"
            :items="items"
            dense
            filled
            label="Filled"
            class="mrb-5"
            test
          ></v-autocomplete>
        </v-col>
```

результат из оригинала
```html
<div class="col col-12">
  <div
    class="v-input mrb-5 v-input--dense theme--light v-text-field v-text-field--filled v-text-field--is-booted v-text-field--enclosed v-select v-autocomplete"
  >
    <div class="v-input__control">
      <div
        role="combobox"
        aria-haspopup="listbox"
        aria-expanded="false"
        aria-owns="list-20"
        class="v-input__slot"
      >
        <div class="v-select__slot">
          <label
            for="input-20"
            class="v-label theme--light"
            style="left: 0px; right: auto; position: absolute"
            >Filled</label
          ><input test="" id="input-20" type="text" autocomplete="off" />
          <div class="v-input__append-inner">
            <div class="v-input__icon v-input__icon--append">
              <i
                aria-hidden="true"
                class="v-icon notranslate mdi mdi-menu-down theme--light"
              ></i>
            </div>
          </div>
          <input type="hidden" />
        </div>
        <div class="v-menu"><!----></div>
      </div>
      <div class="v-text-field__details">
        <div class="v-messages theme--light">
          <div class="v-messages__wrapper"></div>
        </div>
      </div>
    </div>
  </div>
</div>

```
