### PR TITLE
убираем задваивание событий

### DIFF
--- a/packages/vuetify/src/mixins/selectable/index.ts
+++ b/packages/vuetify/src/mixins/selectable/index.ts
@@ -92,7 +92,7 @@ export default mixins(
       if (!label) return label
 
       // Label shouldn't cause the input to focus
-      label!.onClick = prevent
+      label!.onClick = this.onClick
 
       return label
     },
@@ -116,14 +116,8 @@ export default mixins(
       })
     },
     onClick (e: Event) {
-      // тут задваиваются клики
-      const target = e.target as HTMLElement
-      const isCurrentClick = target.id === this.computedId
-      const isRippleClick = target.classList.contains('v-input--selection-controls__ripple')
-
-      if (isCurrentClick || isRippleClick || !this.computedId) {
-        this.onChange();
-      }
+      e.preventDefault()
+      this.onChange()
       this.$emit('click', e)
     },
     onChange () {


### PR DESCRIPTION
чиним задвоение событий

как то иначе вашаются и отрабатывают обработчики

vue2
<img width="1446" height="257" alt="изображение" src="https://github.com/user-attachments/assets/4dd7885e-20a1-4f7c-8ed1-56f67167be9b" />

vue3

<img width="1446" height="257" alt="изображение" src="https://github.com/user-attachments/assets/de9f126f-41bf-468e-91f7-e58ff4cdc571" />


vue2
```
        handler = original_1._wrapper = function (e) {
            if (
            // no bubbling, should always fire.
            // this is just a safety net in case event.timeStamp is unreliable in
            // certain weird environments...
            e.target === e.currentTarget ||
                // event is fired after handler attachment
                e.timeStamp >= attachedTimestamp_1 ||
                // bail for environments that have buggy event.timeStamp implementations
                // #9462 iOS 9 bug: event.timeStamp is 0 after history.pushState
                // #9681 QtWebEngine event.timeStamp is negative value
                e.timeStamp <= 0 ||
                // #9448 bail if event is fired in another document in a multi-page
                // electron/nw.js app, since event.timeStamp will be using a different
                // starting reference
                e.target.ownerDocument !== document) {
                return original_1.apply(this, arguments);
            }
        };
```

veu3
```
function createInvoker(initialValue, instance) {
  const invoker = (e) => {
    if (!e._vts) {
      e._vts = Date.now();
    } else if (e._vts <= invoker.attached) {
      return;
    }
    callWithAsyncErrorHandling(
      patchStopImmediatePropagation(e, invoker.value),
      instance,
      5,
      [e]
    );
  };
  invoker.value = initialValue;
  invoker.attached = getNow();
  return invoker;
}
```

<img width="1427" height="414" alt="изображение" src="https://github.com/user-attachments/assets/f51da252-4392-403a-b7ac-15da804e52d0" />

