### PR TITLE
фикс для ClickOutside

### DIFF
--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
@@ -610,7 +610,7 @@ describe('VSelect.ts', () => {
     const item = document.querySelector('.v-list-item')
     expect(item).toBeTruthy()
     if (item) {
-      ;(item as HTMLElement).click()
+      (item as HTMLElement).click()
     }
     await waitAnimationFrame()
     await selectWrapper.vm.$nextTick()

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
@@ -564,4 +564,58 @@ describe('VSelect.ts', () => {
     // Confirm dialog is still open (проверяем существование)
     expect(dialogWrapper.exists()).toBe(true)
   })
+
+  it('should not treat click on select item as outside dialog', async () => {
+    const items = ['Foo', 'Bar', 'Fizz']
+
+    const dialogWrapper = mount(VDialog, {
+      slots: {
+        default: () => h(VSelect, {
+          items
+        })
+      },
+      props: {
+        modelValue: false,
+        fullscreen: true
+      },
+      global: {
+        mocks: {
+          $vuetify: {
+            lang: {
+              t: (val: string) => val
+            },
+            theme: {
+              dark: false
+            },
+            icons: {
+              component: 'mdi'
+            },
+            breakpoint: {}
+          }
+        }
+      }
+    }) as VueWrapper<InstanceType<typeof VDialog>>
+
+    await dialogWrapper.setProps({ modelValue: true })
+    await dialogWrapper.vm.$nextTick()
+
+    const selectWrapper = dialogWrapper.findComponent(VSelect) as VueWrapper<Instance>
+
+    const inputSlot = selectWrapper.find('.v-input__slot')
+    await inputSlot.trigger('click')
+    await selectWrapper.vm.$nextTick()
+
+    expect(selectWrapper.vm.isMenuActive).toBe(true)
+
+    const item = document.querySelector('.v-list-item')
+    expect(item).toBeTruthy()
+    if (item) {
+      ;(item as HTMLElement).click()
+    }
+    await waitAnimationFrame()
+    await selectWrapper.vm.$nextTick()
+
+    expect(dialogWrapper.emitted('click:outside')).toBeFalsy()
+    expect(dialogWrapper.vm.isActive).toBe(true)
+  })
 })

--- a/packages/vuetify/src/mixins/dependent/index.ts
+++ b/packages/vuetify/src/mixins/dependent/index.ts
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import type { VNode } from 'vue'
 
 import mixins from '../../util/mixins'
 import { VOverlay } from '../../components/VOverlay'
@@ -14,18 +15,27 @@ interface options {
 interface DependentInstance extends Vue {
   isActive?: boolean
   isDependent?: boolean
-  children?: { default?: () => any[] }
+  getClickableDependentElements?: () => HTMLElement[]
 }
 
-function searchChildren (children: any[]): DependentInstance[] {
-  const results = []
-  for (let index = 0; index < children.length; index++) {
-    const child = children[index] as DependentInstance
+function searchVNodeTree (vnodes: VNode[]): DependentInstance[] {
+  const results: DependentInstance[] = []
 
-    if (child.isActive && child.isDependent) {
-      results.push(child)
+  for (const vnode of vnodes) {
+    const proxy = (vnode as any).component?.proxy as DependentInstance | undefined
+
+    if (proxy?.isActive && proxy?.isDependent) {
+      results.push(proxy)
     } else {
-      results.push(...searchChildren(child.children?.default?.() || []))
+      const subTree = (vnode as any).component?.subTree
+      if (subTree) {
+        results.push(...searchVNodeTree(Array.isArray(subTree) ? subTree : [subTree]))
+      }
+
+      const children = (vnode as any).children
+      if (Array.isArray(children)) {
+        results.push(...searchVNodeTree(children))
+      }
     }
   }
 
@@ -57,13 +67,12 @@ export default mixins().extend({
 
   methods: {
     getOpenDependents (): any[] {
-      const node = this.$slots.default?.()
+      if (!this.closeDependents) return []
 
-      if (!node) return []
+      const subTree = (this.$ as any)?.subTree
+      if (!subTree) return []
 
-      if (this.closeDependents) return searchChildren(node)
-
-      return []
+      return searchVNodeTree(Array.isArray(subTree) ? subTree : [subTree])
     },
     getOpenDependentElements (): HTMLElement[] {
       const result = []


### PR DESCRIPTION
Баг: клик по пункту списка VSelect, находящегося внутри VDialog, ошибочно считался кликом «снаружи» диалога, из‑за чего диалог получал click:outside.

В dependent/index.ts функция searchChildren получала массив VNode через this.$slots.default?.() и искала на них свойства isActive и isDependent. Но в Vue 3 $slots.default?.() возвращает свежесозданные VNode-дескрипторы, а не экземпляры компонентов — у них нет этих свойств. Поэтому getOpenDependentElements всегда возвращал пустой массив, и директива ClickOutside на диалоге не знала о телепортированном меню VSelect.