### PR TITLE
fix(vuetify): совместимость Vue 3 VNode и ColorPicker mode

### DIFF
--- a/packages/docs/src/examples/v-color-picker/usage.vue
+++ b/packages/docs/src/examples/v-color-picker/usage.vue
@@ -24,7 +24,7 @@
         'hide-canvas': false,
         'hide-inputs': false,
         'hide-mode-switch': false,
-        mode: null,
+        mode: 'rgba',
         'show-swatches': false,
         'swatches-max-height': 200,
       },

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -167,8 +167,8 @@ export default defineComponent({
     listData () {
       const data = VSelect.computed.listData.call(this) as any
 
-      data.props = {
-        ...data.props,
+      return {
+        ...data,
         items: this.virtualizedItems,
         noFilter: (
           this.noFilter ||
@@ -177,8 +177,6 @@ export default defineComponent({
         ),
         searchInput: this.internalSearch
       }
-
-      return data
     }
   },
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -582,4 +582,21 @@ describe('VAutocomplete.ts', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.selectedItems).toHaveLength(originalLength)
   })
+
+  it('should expose listData props at top level', () => {
+    const wrapper = mountFunction({
+      props: {
+        items: ['foo', 'bar'],
+        searchInput: 'foo',
+        noFilter: true
+      }
+    })
+
+    const listData = wrapper.vm.listData
+
+    expect(listData.props).toBeUndefined()
+    expect(listData.searchInput).toBe('foo')
+    expect(listData.noFilter).toBe(true)
+    expect(listData.items).toEqual(wrapper.vm.virtualizedItems)
+  })
 })

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
@@ -45,6 +45,10 @@ export const modes = {
   }
 } as { [key: string]: Mode }
 
+export function getValidMode (mode?: string | null): string {
+  return mode && Object.keys(modes).includes(mode) ? mode : 'rgba'
+}
+
 export default defineComponent({
   name: 'v-color-picker-edit',
 
@@ -67,19 +71,19 @@ export default defineComponent({
 
   data () {
     return {
-      internalMode: this.mode
+      internalMode: getValidMode(this.mode)
     }
   },
 
   computed: {
     currentMode (): Mode {
-      return modes[this.internalMode]
+      return modes[this.internalMode] || modes.rgba
     }
   },
 
   watch: {
     mode (mode: string) {
-      this.internalMode = mode
+      this.internalMode = getValidMode(mode)
     }
   },
 

--- a/packages/vuetify/src/components/VColorPicker/__tests__/VColorPickerEdit.spec.ts
+++ b/packages/vuetify/src/components/VColorPicker/__tests__/VColorPickerEdit.spec.ts
@@ -132,6 +132,17 @@ describe('VColorPickerEdit.ts', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should fallback to rgba mode when mode is null', () => {
+    const wrapper = mountFunction({
+      props: {
+        color: fromRGBA({ r: 0, g: 0, b: 0, a: 0 }),
+        mode: null as any
+      }
+    })
+
+    expect(wrapper.findAll('input')).toHaveLength(4)
+  })
+
   it('should hide mode switch button', () => {
     const wrapper = mountFunction({
       props: {

--- a/packages/vuetify/src/components/VContent/VContent.ts
+++ b/packages/vuetify/src/components/VContent/VContent.ts
@@ -21,16 +21,18 @@ export default defineComponent({
     // Add the legacy class names
     const node = VMain.render.call(this, h)
 
-    const existingClasses = node.data?.class || ''
+    const existingClasses = node.props?.class || ''
     const contentClasses = normalizeClasses(`${existingClasses} v-content`)
-    node.data = { ...node.data, class: contentClasses }
 
-    if (node.children && node.children[0] && node.children[0].data) {
-      const childExistingClasses = node.children[0].data.class || ''
+    const children = (node.children as VNode[] | undefined)?.map((child, i) => {
+      if (i !== 0) return child
+
+      const childExistingClasses = child.props?.class || ''
       const wrapClasses = normalizeClasses(`${childExistingClasses} v-content__wrap`)
-      node.children[0].data = { ...node.children[0].data, class: wrapClasses }
-    }
 
-    return h(getTagValue(this.tag), node.data, node.children)
+      return h('div', { ...child.props, class: wrapClasses }, child.children as any)
+    })
+
+    return h(getTagValue(this.tag), { ...node.props, class: contentClasses }, children ?? node.children)
   }
 })

--- a/packages/vuetify/src/components/VContent/__tests__/VContent.spec.ts
+++ b/packages/vuetify/src/components/VContent/__tests__/VContent.spec.ts
@@ -1,0 +1,40 @@
+// Components
+import VContent from '../VContent'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+
+describe('VContent.ts', () => {
+  let mountFunction: (options?: any) => any
+
+  beforeEach(() => {
+    mountFunction = (options = {}) => {
+      return mount(VContent, {
+        ...options,
+        global: {
+          mocks: {
+            $vuetify: {
+              application: {
+                bar: 24,
+                top: 64,
+                left: 256,
+                right: 256,
+                footer: 48,
+                insetFooter: 32,
+                bottom: 56
+              }
+            }
+          }
+        }
+      })
+    }
+  })
+
+  it('should apply legacy v-content classes', () => {
+    const wrapper = mountFunction()
+
+    expect('[Vuetify] [UPGRADE] \'v-content\' is deprecated, use \'v-main\' instead.').toHaveBeenTipped()
+    expect(wrapper.classes()).toContain('v-content')
+    expect(wrapper.find('.v-content__wrap').exists()).toBe(true)
+  })
+})

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
@@ -112,10 +112,11 @@ export default defineComponent({
       return createRange(2).map(i => {
         const input = VSlider.methods.genInput.call(this)
 
-        input.data = input.data || {}
-        input.data.attrs = input.data.attrs || {}
-        input.data.attrs.value = this.internalValue[i]
-        input.data.attrs.id = `input-${i ? 'max' : 'min'}-${this.$.uid}`
+        input.props = {
+          ...input.props,
+          value: this.internalValue[i],
+          id: `input-${i ? 'max' : 'min'}-${this.$.uid}`
+        }
 
         return input
       })

--- a/packages/vuetify/src/components/VRangeSlider/__tests__/VRangeSlider.spec.ts
+++ b/packages/vuetify/src/components/VRangeSlider/__tests__/VRangeSlider.spec.ts
@@ -191,7 +191,10 @@ describe('VRangeSlider', () => {
     const wrapper = mountFunction()
     const [min, max] = wrapper.vm.genInput()
 
-    expect(min.data.attrs.id).not.toEqual(max.data.attrs.id)
+    expect(min.props!.id).not.toEqual(max.props!.id)
+
+    const inputs = wrapper.findAll('input')
+    expect(inputs[0].attributes('id')).not.toEqual(inputs[1].attributes('id'))
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/12733

--- a/packages/vuetify/src/components/VRangeSlider/__tests__/__snapshots__/VRangeSlider.spec.ts.snap
+++ b/packages/vuetify/src/components/VRangeSlider/__tests__/__snapshots__/VRangeSlider.spec.ts.snap
@@ -5,17 +5,17 @@ exports[`VRangeSlider should render a vertical slider 1`] = `
   <div class="v-input__control">
     <div class="v-input__slot">
       <div class="v-slider v-slider--vertical theme--light">
-        <input id="input-25"
+        <input id="input-min-25"
                disabled
                readonly
                tabindex="-1"
-               value="0,0"
+               value="0"
         >
-        <input id="input-25"
+        <input id="input-max-25"
                disabled
                readonly
                tabindex="-1"
-               value="0,0"
+               value="0"
         >
         <div class="v-slider__track-container">
           <div class="v-slider__track-background primary lighten-3">
@@ -66,17 +66,17 @@ exports[`VRangeSlider should render disabled slider 1`] = `
   <div class="v-input__control">
     <div class="v-input__slot">
       <div class="v-slider v-slider--horizontal v-slider--disabled theme--light">
-        <input id="input-29"
+        <input id="input-min-29"
                disabled
                readonly
                tabindex="-1"
-               value="0,0"
+               value="0"
         >
-        <input id="input-29"
+        <input id="input-max-29"
                disabled
                readonly
                tabindex="-1"
-               value="0,0"
+               value="0"
         >
         <div class="v-slider__track-container">
           <div class="v-slider__track-background">

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -505,7 +505,7 @@ export default baseMixins.extend({
         type: 'text',
         'aria-readonly': String(this.isReadonly),
         'aria-activedescendant': getObjectValueByPath(this.$refs.menu, 'activeTile.id'),
-        autocomplete: getObjectValueByPath(input.data!, 'attrs.autocomplete', 'off'),
+        autocomplete: getObjectValueByPath(input.props, 'autocomplete', 'off'),
         placeholder: (!this.isDirty && (this.persistentPlaceholder || this.isFocused || !this.hasLabel)) ? this.placeholder : undefined,
         onKeypress: this.onKeyPress
       })

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.ts
@@ -490,6 +490,7 @@ describe('VSelect.ts', () => {
     })
 
     expect(wrapper.vm.$attrs.autocomplete).toBe('on')
+    expect(wrapper.find('input').attributes('autocomplete')).toBe('on')
   })
 
   // Based on issue: https://github.com/vuetifyjs/vuetify/issues/12769


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
